### PR TITLE
Add region and platform reports to source models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -18,5 +18,7 @@ vars:
     basic_ad: "{{ source('facebook_ads','basic_ad') }}"
     campaign_history: "{{ source('facebook_ads','campaign_history') }}"
     creative_history: "{{ source('facebook_ads','creative_history') }}"
+    basic_ad_platform: "{{ source('facebook_ads','basic_ad_platform') }}"
+    basic_ad_region: "{{ source('facebook_ads','basic_ad_region') }}"
 
   facebook_ads__basic_ad_passthrough_metrics: []

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -18,5 +18,5 @@ vars:
     basic_ad: "{{ source('facebook_ads','basic_ad') }}"
     campaign_history: "{{ source('facebook_ads','campaign_history') }}"
     creative_history: "{{ source('facebook_ads','creative_history') }}"
-  
+
   facebook_ads__basic_ad_passthrough_metrics: []

--- a/macros/get_basic_ad_platform_columns.sql
+++ b/macros/get_basic_ad_platform_columns.sql
@@ -1,0 +1,20 @@
+{% macro get_basic_ad_platform_columns() %}
+
+{% set columns = [
+    {"name": "ad_id", "datatype": dbt_utils.type_string()},
+    {"name": "ad_name", "datatype": dbt_utils.type_string()},
+    {"name": "adset_name", "datatype": dbt_utils.type_string()},
+    {"name": "date", "datatype": "date"},
+    {"name": "account_id", "datatype": dbt_utils.type_int()},
+    {"name": "impressions", "datatype": dbt_utils.type_int()},
+    {"name": "inline_link_clicks", "datatype": dbt_utils.type_int()},
+    {"name": "spend", "datatype": dbt_utils.type_float()},
+    {"name": "reach", "datatype": dbt_utils.type_int()},
+    {"name": "publisher_platform", "datatype": dbt_utils.type_string()}
+] %}
+
+{{ fivetran_utils.add_pass_through_columns(columns, var('facebook_ads__basic_ad_passthrough_metrics')) }}
+
+{{ return(columns) }}
+
+{% endmacro %}

--- a/macros/get_basic_ad_region_columns.sql
+++ b/macros/get_basic_ad_region_columns.sql
@@ -1,0 +1,20 @@
+{% macro get_basic_ad_region_columns() %}
+
+{% set columns = [
+    {"name": "ad_id", "datatype": dbt_utils.type_string()},
+    {"name": "ad_name", "datatype": dbt_utils.type_string()},
+    {"name": "adset_name", "datatype": dbt_utils.type_string()},
+    {"name": "date", "datatype": "date"},
+    {"name": "account_id", "datatype": dbt_utils.type_int()},
+    {"name": "impressions", "datatype": dbt_utils.type_int()},
+    {"name": "inline_link_clicks", "datatype": dbt_utils.type_int()},
+    {"name": "spend", "datatype": dbt_utils.type_float()},
+    {"name": "reach", "datatype": dbt_utils.type_int()},
+    {"name": "region", "datatype": dbt_utils.type_string()}
+] %}
+
+{{ fivetran_utils.add_pass_through_columns(columns, var('facebook_ads__basic_ad_passthrough_metrics')) }}
+
+{{ return(columns) }}
+
+{% endmacro %}

--- a/models/src_facebook_ads.yml
+++ b/models/src_facebook_ads.yml
@@ -4,17 +4,17 @@ sources:
   - name: facebook_ads
     schema: "{{ var('facebook_ads_schema', 'facebook_ads') }}"
     database: "{% if target.type != 'spark'%}{{ var('facebook_ads_database', target.database) }}{% endif %}"
-    
+
     loader: Fivetran
     loaded_at_field: _fivetran_synced
-    
-    freshness: 
+
+    freshness:
       warn_after: {count: 48, period: hour}
       error_after: {count: 168, period: hour}
 
     config:
       enabled: "{{ var('ad_reporting__facebook_ads_enabled', true) }}"
-      
+
     tables:
       - name: account_history
         description: Each record in this table reflects a version of a Facebook ad account.
@@ -159,7 +159,7 @@ sources:
             description: Ad account ID for the account this ad creative belongs to.
           - name: name
             description: Name of this ad creative as seen in the ad account's library.
-          - name: url_tags        
+          - name: url_tags
             description: A set of query string parameters which will replace or be appended to urls clicked from page post ads, message of the post, and canvas app install creatives only.
           - name: _fivetran_synced
             description: "{{ doc('_fivetran_synced') }}"
@@ -185,3 +185,69 @@ sources:
             description: Link of the template app for android
           - name: template_app_link_spec_iphone
             description: Link of the template app for iphone
+
+      - name: basic_ad_platform
+        description: Each record represents the daily performance of an ad in Facebook, broken out by the platform (Facebook or Instagram).
+        identifier: "{{ var('facebook_ads_basic_ad_identifier', 'basic_ad') }}"
+        columns:
+          - name: ad_id
+            description: The ID of the ad the report relates to.
+          - name: ad_name
+            description: Name of the ad the report relates to.
+          - name: adset_name
+            description: Name of the ad set the report relates to.
+          - name: date
+            description: The date of the reported performance.
+          - name: account_id
+            description: The ID of the ad account that this ad belongs to.
+          - name: account_name
+            description: Name of the account that this ad belongs to.
+          - name: campaign_id
+            description: The ID of the campaign the ad belongs to.
+          - name: campaign_name
+            description: Name of the campaign the ad belongs to.
+          - name: publisher_platform
+            description: The platform the ad was published on, either 'facebook' or 'instagram'.
+          - name: impressions
+            description: The number of impressions the ad had on the given day.
+          - name: inline_link_clicks
+            description: The number of clicks the ad had on the given day.
+          - name: spend
+            description: The spend on the ad in the given day.
+          - name: reach
+            description: The number of people who saw any content from your Page or about your Page. This metric is estimated.
+          - name: _fivetran_synced
+            description: "{{ doc('_fivetran_synced') }}"
+
+      - name: basic_ad_region
+        description: Each record represents the daily performance of an ad in Facebook, broken out by the platform (Facebook or Instagram).
+        identifier: "{{ var('facebook_ads_basic_ad_identifier', 'basic_ad') }}"
+        columns:
+          - name: ad_id
+            description: The ID of the ad the report relates to.
+          - name: ad_name
+            description: Name of the ad the report relates to.
+          - name: adset_name
+            description: Name of the ad set the report relates to.
+          - name: date
+            description: The date of the reported performance.
+          - name: account_id
+            description: The ID of the ad account that this ad belongs to.
+          - name: account_name
+            description: Name of the account that this ad belongs to.
+          - name: campaign_id
+            description: The ID of the campaign the ad belongs to.
+          - name: campaign_name
+            description: Name of the campaign the ad belongs to.
+          - name: region
+            description: The region the ad was served in. For US regions this is the full state name (e.g. 'Alaska' or 'Alabama').
+          - name: impressions
+            description: The number of impressions the ad had on the given day.
+          - name: inline_link_clicks
+            description: The number of clicks the ad had on the given day.
+          - name: spend
+            description: The spend on the ad in the given day.
+          - name: reach
+            description: The number of people who saw any content from your Page or about your Page. This metric is estimated.
+          - name: _fivetran_synced
+            description: "{{ doc('_fivetran_synced') }}"

--- a/models/src_facebook_ads.yml
+++ b/models/src_facebook_ads.yml
@@ -188,7 +188,7 @@ sources:
 
       - name: basic_ad_platform
         description: Each record represents the daily performance of an ad in Facebook, broken out by the platform (Facebook or Instagram).
-        identifier: "{{ var('facebook_ads_basic_ad_identifier', 'basic_ad') }}"
+        identifier: "{{ var('facebook_ads_basic_ad_identifier', 'basic_ad_platform') }}"
         columns:
           - name: ad_id
             description: The ID of the ad the report relates to.
@@ -221,7 +221,7 @@ sources:
 
       - name: basic_ad_region
         description: Each record represents the daily performance of an ad in Facebook, broken out by the platform (Facebook or Instagram).
-        identifier: "{{ var('facebook_ads_basic_ad_identifier', 'basic_ad') }}"
+        identifier: "{{ var('facebook_ads_basic_ad_identifier', 'basic_ad_region') }}"
         columns:
           - name: ad_id
             description: The ID of the ad the report relates to.

--- a/models/stg_facebook_ads__basic_ad_platform.sql
+++ b/models/stg_facebook_ads__basic_ad_platform.sql
@@ -1,0 +1,41 @@
+{{ config(enabled=var('ad_reporting__facebook_ads_enabled', True)) }}
+
+with base as (
+
+    select *
+    from {{ ref('stg_facebook_ads__basic_ad_platform_tmp') }}
+),
+
+fields as (
+
+    select
+        {{
+            fivetran_utils.fill_staging_columns(
+                source_columns=adapter.get_columns_in_relation(ref('stg_facebook_ads__basic_ad_platform_tmp')),
+                staging_columns=get_basic_ad_platform_columns()
+            )
+        }}
+
+    from base
+),
+
+final as (
+
+    select
+        cast(ad_id as {{ dbt_utils.type_bigint() }}) as ad_id,
+        ad_name,
+        adset_name as ad_set_name,
+        publisher_platform as platform,
+        date as date_day,
+        cast(account_id as {{ dbt_utils.type_bigint() }}) as account_id,
+        impressions,
+        coalesce(inline_link_clicks,0) as clicks,
+        spend,
+        reach
+
+        {{ fivetran_utils.fill_pass_through_columns('facebook_ads__basic_ad_passthrough_metrics') }}
+    from fields
+)
+
+select *
+from final

--- a/models/stg_facebook_ads__basic_ad_region.sql
+++ b/models/stg_facebook_ads__basic_ad_region.sql
@@ -1,0 +1,41 @@
+{{ config(enabled=var('ad_reporting__facebook_ads_enabled', True)) }}
+
+with base as (
+
+    select *
+    from {{ ref('stg_facebook_ads__basic_ad_region_tmp') }}
+),
+
+fields as (
+
+    select
+        {{
+            fivetran_utils.fill_staging_columns(
+                source_columns=adapter.get_columns_in_relation(ref('stg_facebook_ads__basic_ad_tmp')),
+                staging_columns=get_basic_ad_region_columns()
+            )
+        }}
+
+    from base
+),
+
+final as (
+
+    select
+        cast(ad_id as {{ dbt_utils.type_bigint() }}) as ad_id,
+        ad_name,
+        adset_name as ad_set_name,
+        region,
+        date as date_day,
+        cast(account_id as {{ dbt_utils.type_bigint() }}) as account_id,
+        impressions,
+        coalesce(inline_link_clicks,0) as clicks,
+        spend,
+        reach
+
+        {{ fivetran_utils.fill_pass_through_columns('facebook_ads__basic_ad_passthrough_metrics') }}
+    from fields
+)
+
+select *
+from final

--- a/models/stg_facebook_ads__basic_ad_region.sql
+++ b/models/stg_facebook_ads__basic_ad_region.sql
@@ -11,7 +11,7 @@ fields as (
     select
         {{
             fivetran_utils.fill_staging_columns(
-                source_columns=adapter.get_columns_in_relation(ref('stg_facebook_ads__basic_ad_tmp')),
+                source_columns=adapter.get_columns_in_relation(ref('stg_facebook_ads__basic_ad_region_tmp')),
                 staging_columns=get_basic_ad_region_columns()
             )
         }}

--- a/models/tmp/stg_facebook_ads__basic_ad_platform_tmp.sql
+++ b/models/tmp/stg_facebook_ads__basic_ad_platform_tmp.sql
@@ -1,4 +1,4 @@
 {{ config(enabled=var('ad_reporting__facebook_ads_enabled', True)) }}
 
 select *
-from {{ source('facebook_ads', 'basic_ad_platform') }}
+from {{ var('basic_ad_platform') }}

--- a/models/tmp/stg_facebook_ads__basic_ad_platform_tmp.sql
+++ b/models/tmp/stg_facebook_ads__basic_ad_platform_tmp.sql
@@ -1,0 +1,4 @@
+{{ config(enabled=var('ad_reporting__facebook_ads_enabled', True)) }}
+
+select *
+from {{ source('facebook_ads', 'basic_ad_platform') }}

--- a/models/tmp/stg_facebook_ads__basic_ad_region_tmp.sql
+++ b/models/tmp/stg_facebook_ads__basic_ad_region_tmp.sql
@@ -1,4 +1,4 @@
 {{ config(enabled=var('ad_reporting__facebook_ads_enabled', True)) }}
 
 select *
-from {{ source('facebook_ads', 'basic_ad_region') }}
+from {{ var('basic_ad_region') }}

--- a/models/tmp/stg_facebook_ads__basic_ad_region_tmp.sql
+++ b/models/tmp/stg_facebook_ads__basic_ad_region_tmp.sql
@@ -1,0 +1,4 @@
+{{ config(enabled=var('ad_reporting__facebook_ads_enabled', True)) }}
+
+select *
+from {{ source('facebook_ads', 'basic_ad_region') }}


### PR DESCRIPTION
We're syncing two custom reports from the Fivetran Facebook Ads connector to introduce ad-platform and ad-region level granularity. Both of these are essentially slimmed down variations on the `basic_ad` report. This PR sources and stages these models using the conventions of the original package. 